### PR TITLE
Add VSCode instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,43 @@
 # Beatmap Schemas
 _A collection of JSON Schemas for Beat Saber's Level Format_
+
+# VSCode setup
+
+It's possible to set [VSCode](https://code.visualstudio.com/) to format, validate, and display tooltip hints for beatmap files using this schema.
+
+## Access the VSCode settings.json file:
+In VSCode, click on `File -> Preferences -> Settings` then click on the `Open Settings (JSON)` button in the top right corner of the page.
+
+## Add the following code to your VSCode settings.json file.
+```json
+"files.associations": {
+    "*.dat": "json"
+},
+"json.schemas": [
+    {
+        "fileMatch": [
+            "Easy*.dat",
+            "Normal*.dat",
+            "Hard*.dat",
+            "Expert*.dat",
+            "ExpertPlus*.dat"
+        ],
+        "url": "https://raw.githubusercontent.com/lolPants/beatmap-schemas/master/schemas/difficulty.schema.json"
+    },
+    {
+        "fileMatch": [
+            "info.dat"
+        ],
+        "url": "https://raw.githubusercontent.com/lolPants/beatmap-schemas/master/schemas/info.schema.json"
+    }
+]
+```
+
+## Open a beatmap in VSCode
+Now when you open a beatmap file in VSCode, you can format the document using the default JSON formatting by pressing:
+`Shift + Alt + F` on Windows
+`Shift + Option + F` on Mac
+
+If any invalid data is found, it should be noted with a squigly underline.
+
+You can also see the descriptions for each property by hovering over the name of the property.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # Beatmap Schemas
 _A collection of JSON Schemas for Beat Saber's Level Format_
 
-# VSCode setup
+# VS Code setup
 
-It's possible to set [VSCode](https://code.visualstudio.com/) to format, validate, and display tooltip hints for beatmap files using this schema.
+It's possible to set [VS Code](https://code.visualstudio.com/) to format, validate, and display tooltip hints for beatmap files using this schema.
 
-## Access the VSCode settings.json file:
-In VSCode, click on `File -> Preferences -> Settings` then click on the `Open Settings (JSON)` button in the top right corner of the page.
+## Access the VS Code settings.json file:
+In VS Code, click on `File -> Preferences -> Settings` then click on the `Open Settings (JSON)` button in the top right corner of the page.
 
-## Add the following code to your VSCode settings.json file.
+## Add the following code to your VS Code settings.json file.
 ```json
 "files.associations": {
     "*.dat": "json"
@@ -33,8 +33,8 @@ In VSCode, click on `File -> Preferences -> Settings` then click on the `Open Se
 ]
 ```
 
-## Open a beatmap in VSCode
-Now when you open a beatmap file in VSCode, you can format the document using the default JSON formatting by pressing:
+## Open a beatmap in VS Code
+Now when you open a beatmap file in VS Code, you can format the document using the default JSON formatting by pressing:
 `Shift + Alt + F` on Windows
 `Shift + Option + F` on Mac
 


### PR DESCRIPTION
Explains how to add the schema into VSCode's user settings to take advantage of the usual JSON formatting, validation, autocomplete, and tooltip suggestions that regular JSON files have.

![image](https://user-images.githubusercontent.com/27714637/72944159-f8c90380-3d2c-11ea-9f4b-878d58917ab2.png)
